### PR TITLE
Clean up modding tutorial and other things

### DIFF
--- a/src/en/guide/mod/format.md
+++ b/src/en/guide/mod/format.md
@@ -1,5 +1,5 @@
 ---
-title: Attribute Reference(latest)
+title: Attribute Reference (latest)
 icon: file-invoice
 pageInfo: false
 index: true
@@ -14,10 +14,10 @@ order: 2
 </script>
 
 > [!warning]
-> The following tutorial is only applicable to version `0.3.X`.
+> The following tutorial only works for versions `0.3.X`.
 
 > [!important]
-> In the tables, attributes in _italics_ are fields that are not recommended to be modified. Modifying them may cause the game to crash or not run properly.
+> In the tables, attributes in _italics_ are fields that are not recommended to be modified. Modifying them may cause the game to crash or bug out.
 
 <ins class="adsbygoogle"
      style="display:block"
@@ -57,21 +57,21 @@ Each plant in the `PLANTS` array includes the following basic characteristics fi
 | **ZENGARDEN**      | `{ "PlantPlace": "dirt" }`                | Zen Garden planting location:<br>- `dirt`: Normal soil                                                 |
 | _COSTUME_          | 2                                         | Number of costumes                                                                                     |
 
-The `SEEDCHOOSERDEFAULTORDER` array is used to specify the default order of plants in the selection interface. Each item's value is the plant's `CODENAME`.
+The `SEEDCHOOSERDEFAULTORDER` array is used to specify the default order of plants in the selection interface. It should only have plants' `CODENAME` and the order they are in the array is the order they will appear in the almanac, seed chooser, etc.
 
-The `BASEUNLOCKLIST` array contains all plants designated for initial unlock. Each item's value is the plant's `CODENAME`.
+The `BASEUNLOCKLIST` array contains plants newly created player profiles have by default. It also uses plants' `CODENAME`.
 
 ### PlantAlmanac.json
 
 The PlantAlmanac.json file contains the Almanac information for plants.
 
-Each item in the `objects` array includes `aliases`, `objclass`, and `objdata`.
+Each item in the `objects` array should include `aliases`, `objclass`, and `objdata`, or else it may not change in-game.
 
-The `aliases` array contains the plant's `CODENAME`, used to indicate the corresponding plant for this item. The value of `objclass` is `PlantAlmanacProperties`, indicating that this item is a plant almanac property.
+The `aliases` array contains the plant's `CODENAME`, used to indicate the corresponding plant for this object. Only the first item is read from at the moment. The value of `objclass` is `PlantAlmanacProperties`, indicating that this object modifies a plant almanac entry.
 
-`objdata` includes the following Almanac information fields:
+`objdata` includes the following Almanac properties:
 
-| Field                 | Value/Content                                                                                                                                                     | Description                                              |
+| Property              | Value/Content                                                                                                                                                     | Description                                              |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | _Elements_            | Contains multiple attribute tags:<br>- `SUNCOST`:Sun cost<br>- `RECHARGE`:Cooldown<br>- `DAMAGE`:Damage value (1800)<br>- `AREA`:Range (3x3)<br>- `FAMILY`:Family | Key attribute tags shown in Almanac                      |
 | **Introduction**      | `{ "en": "...", "zh": "爆炸后向 8 个方向发射弹性葡萄子弹" }`                                                                                                      | Multilingual description of plant function               |
@@ -82,15 +82,15 @@ The `aliases` array contains the plant's `CODENAME`, used to indicate the corres
 
 ### PlantProps.json
 
-The PlantProps.json file contains the numerical attributes of plants.
+The PlantProps.json file contains gameplay attributes of plants.
 
-Each item in the `objects` array includes `aliases`, `objclass`, and `objdata`.
+Each item in the `objects` array includes `aliases`, `objclass`, and `objdata`, just like in `PlantAlmanac.json`.
 
-The `aliases` array contains the plant's `CODENAME`, used to indicate the corresponding plant for this item. The value of `objclass` is `PlantProperties`, indicating that this item is a plant numerical property.
+The `aliases` array contains the plant's `CODENAME`, used to indicate the corresponding plant for this object. Again, only the first entry is read. The value of `objclass` is `PlantProperties`, indicating that this object modifies a plant's gameplay properties.
 
-`objdata` includes the following numerical attribute fields. Valid Props for each plant can be viewed in the [Almanac](../../almanac/):
+`objdata` includes the following properties, but some plants have properties others don't. Valid properties for each plant can be viewed in the [Almanac](../../almanac/).
 
-| Attribute                     | Value/Content | Description                                             |
+| Property                      | Value/Content | Description                                             |
 | ----------------------------- | ------------- | ------------------------------------------------------- |
 | **CannotBeSheepenedByWizard** | true          | Immune to Wizard Zombie's "sheep transformation" skill  |
 | **Damage**                    | 1800          | Base damage value                                       |
@@ -109,7 +109,7 @@ The `StoreCommodityFeatures.json` file contains store commodity information, inc
 
 The `Plants` array contains information about plant commodities.
 
-| Field                | Type   | Description                     |
+| Property             | Type   | Description                     |
 | -------------------- | ------ | ------------------------------- |
 | _CommodityType_      | string | Fixed value "plant"             |
 | **CommodityName**    | string | Plant's CODENAME                |
@@ -132,7 +132,7 @@ The `Plants` array contains information about plant commodities.
 
 The `Upgrade` array contains information about plant upgrade commodities.
 
-| Field                | Type   | Description                     |
+| Property             | Type   | Description                     |
 | -------------------- | ------ | ------------------------------- |
 | _CommodityType_      | string | Fixed value "upgrade"           |
 | **CommodityName**    | string | CODENAME of the upgrade item    |
@@ -154,7 +154,7 @@ The `Upgrade` array contains information about plant upgrade commodities.
 
 The `Gem` array contains information about Gem commodities.
 
-| Field                    | Description                           |
+| Property                 | Description                           |
 | ------------------------ | ------------------------------------- |
 | _CommodityType_          | Fixed value "gem"                     |
 | CommodityCount           | Amount of Gems obtained               |
@@ -183,7 +183,7 @@ The `Gem` array contains information about Gem commodities.
 
 The `Coin` array contains information about Coin commodities.
 
-| Field                    | Description                           |
+| Property                 | Description                           |
 | ------------------------ | ------------------------------------- |
 | _CommodityType_          | Fixed value "coin"                    |
 | CommodityCount           | Amount of Coins obtained              |

--- a/src/en/guide/mod/format.md
+++ b/src/en/guide/mod/format.md
@@ -1,5 +1,5 @@
 ---
-title: Attribute Reference (latest)
+title: Properties Reference (latest)
 icon: file-invoice
 pageInfo: false
 index: true
@@ -17,7 +17,7 @@ order: 2
 > The following tutorial only works for versions `0.3.X`.
 
 > [!important]
-> In the tables, attributes in _italics_ are fields that are not recommended to be modified. Modifying them may cause the game to crash or bug out.
+> In the tables, properties in _italics_ are properties that you probably shouldn't modify. Modifying them may cause the game to crash or bug out.
 
 <ins class="adsbygoogle"
      style="display:block"
@@ -31,7 +31,7 @@ order: 2
 
 Below is the format of the plant JSON files, using Grapeshot as an example.
 
-Attributes with multilingual values cannot be deleted or have extra fields added. The format must be as follows:
+Properties with multilingual values cannot be deleted or have extra fields added. The format must be as follows:
 
 ```json
 {
@@ -73,7 +73,7 @@ The `aliases` array contains the plant's `CODENAME`, used to indicate the corres
 
 | Property              | Value/Content                                                                                                                                                     | Description                                              |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| _Elements_            | Contains multiple attribute tags:<br>- `SUNCOST`:Sun cost<br>- `RECHARGE`:Cooldown<br>- `DAMAGE`:Damage value (1800)<br>- `AREA`:Range (3x3)<br>- `FAMILY`:Family | Key attribute tags shown in Almanac                      |
+| _Elements_            | Contains multiple properties:<br>- `SUNCOST`:Sun cost<br>- `RECHARGE`:Cooldown<br>- `DAMAGE`:Damage value (1800)<br>- `AREA`:Range (3x3)<br>- `FAMILY`:Family | Key property  tags shown in Almanac                      |
 | **Introduction**      | `{ "en": "...", "zh": "爆炸后向 8 个方向发射弹性葡萄子弹" }`                                                                                                      | Multilingual description of plant function               |
 | _Special_             | `{ "NAME": {"en":"...","zh":"..."}, "DESCRIPTION": {"en":"...","zh":"..."} }`                                                                                     | Special mechanism description                            |
 | **Chat**              | `{"en":"...","zh":"..."}`                                                                                                                                         | Multilingual, plant's personality lines                  |
@@ -82,7 +82,7 @@ The `aliases` array contains the plant's `CODENAME`, used to indicate the corres
 
 ### PlantProps.json
 
-The PlantProps.json file contains gameplay attributes of plants.
+The PlantProps.json file contains gameplay properties of plants.
 
 Each item in the `objects` array includes `aliases`, `objclass`, and `objdata`, just like in `PlantAlmanac.json`.
 

--- a/src/en/guide/mod/format.md
+++ b/src/en/guide/mod/format.md
@@ -44,9 +44,9 @@ Attributes with multilingual values cannot be deleted or have extra fields added
 
 The PlantFeatures.json file contains the basic characteristics of plants.
 
-Each plant in the `PLANTS` array includes the following basic characteristics fields:
+Each plant in the `PLANTS` array includes the following properties:
 
-| Attribute          | Sample Content                            | Description                                                                                            |
+| Property           | Example Content                           | Description                                                                                            |
 | ------------------ | ----------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | **ID**             | 74                                        | Unique ID value of the plant in the game                                                               |
 | **NAME**           | `{ "en": "Grapeshot", "zh": "爆裂葡萄" }` | Multilingual name, `en` for English name, `zh` for Chinese name                                        |

--- a/src/en/guide/mod/patcher.md
+++ b/src/en/guide/mod/patcher.md
@@ -14,17 +14,17 @@ order: 1
 </script>
 
 > [!warning]
-> This tutorial is only applicable to version `0.3.X`.
+> This tutorial is only works for versions `0.3.X`.
 
 GE Patcher is a tool used to modify Plants vs. Zombies 2 Gardendless game data, supporting custom modifications to plants, zombies, upgrades, the shop, levels, and more.
 
-The version provided on the official website has the GE Patcher tool built-in.
+The version provided on the official website has the GE Patcher tool built-in to the PC build.
 
 ## Prerequisites
 
 1. JSON editor (VSCode/Notepad++ recommended)
 2. Game version ≥ 0.3.0
-3. JSON attribute structures for elements like plants and zombies. Please refer to [Attribute Reference](format.md).
+3. [Property Reference](format.md).
 
 <ins class="adsbygoogle"
 style="display:block"
@@ -34,33 +34,23 @@ data-ad-format="auto"
 data-full-width-responsive="true">
 </ins>
 
-## GE Patcher Basics
+## The Basics
 
-Press "F12" when the game starts to open the developer console. In the Console tab, output similar to the following will appear:
+Press `F12` when the game starts to open the developer console. In the Console tab, you should see something like this:
 
 ```
 [GE Patcher] BaseDir: C:\Users\admin\AppData\Local\com.pvzge.app
 ```
 
-The path provided is the GE Patcher's main directory.
+This path is GE Patcher's main directory and where patch files are loaded from. If you want to see _exactly_ where the files are loaded from, enter the command `gePatcher.help()`.
 
-Enter the following command to view in-game help, including the paths for custom JSON files:
+Once you see the title screen, you can now load your patch. **Entering `gePatcher.init()` into the console will load your custom files.**
 
-```javascript
-gePatcher.help()
-```
-
-After the game finishes loading, run the following command to load all custom JSON files:
-
-```javascript
-gePatcher.init()
-```
-
-**After modifying a JSON file, please re-execute this command to apply the changes.**
+After modifying a JSON file, please **run this command again to apply the changes**.
 
 ## File Structure
 
-Create a `patches` folder within `com.pvzge.app` with the following structure:
+To start your patch, create a `patches` folder within `com.pvzge.app` with the following structure (not all files have to be present):
 
 ```
 patches/
@@ -75,22 +65,22 @@ patches/
     │   ├── UpgradeFeatures.json
     │   └── StoreCommodityFeatures.json
     └── levels/
-        └── [LevelName].json
+        └── [LevelName].json (does not support JSON5)
 ```
 
 The `features` directory contains `Features`, `Props`, and `Almanac` files for modifying plants, zombies, upgrades, the shop, etc.
 
-Files under the `levels` directory are used to modify levels.
+Files under the `levels` directory are used to replace levels. If you want to get the original levels, try to find similar ones in vanilla PvZ2 (extracting PvZ2 files are out of the scope of this guide).
 
-Files for original content that are not modified do not need to be created.
+Anything you don't modify will default to the base-game properties.
 
 ## Features Files
 
 ### Features File Structure
 
-Features files contain the basic attributes of plants, zombies, and upgrades. The file structure is as follows:
+Features files contain the basic properties of plants, zombies, and upgrades. The file structure is as follows:
 
-**PlantFeatures.json**：Plant basic characteristics (structure example)
+**PlantFeatures.json**
 
 ```json
 {
@@ -104,7 +94,7 @@ Features files contain the basic attributes of plants, zombies, and upgrades. Th
 }
 ```
 
-**ZombieFeatures.json**：Zombie basic characteristics (structure example)
+**ZombieFeatures.json**
 
 ```json
 {
@@ -116,7 +106,7 @@ Features files contain the basic attributes of plants, zombies, and upgrades. Th
 }
 ```
 
-**UpgradeFeatures.json**：Upgrade attributes (structure example)
+**UpgradeFeatures.json**
 
 ```json
 {
@@ -131,8 +121,8 @@ Features files contain the basic attributes of plants, zombies, and upgrades. Th
 **Key Notes**
 
 - The `PLANTS`、`ZOMBIES` and `UPGRADES` arrays define modifications to existing entities.
-- `SEEDCHOOSERDEFAULTORDER` sets the default plant order in the seed chooser.
-- `BASEUNLOCKLIST` defines initially unlocked plants.
+- `SEEDCHOOSERDEFAULTORDER` sets the order of plants. The order of the array is the order they appear in the almanac, seed chooser, etc.
+- `BASEUNLOCKLIST` defines plants unlocked by default on new player profiles.
 
 ### Features Modification Rules
 
@@ -140,20 +130,20 @@ Features modification rules apply to `PlantFeatures`、`ZombieFeatures` and `Upg
 
 Each object in the `PLANTS` (or `ZOMBIES`, `UPGRADES`) array will be merged into the original JSON after matching by the `CODENAME` field. The merging rules are as follows:
 
-- **Array Elements**: If the attribute type is an array, each value in the array will be merged according to element order. If a value in the array is an object, it will be merged recursively. If a value in the array is a primitive type, it will directly overwrite the value in the original JSON.
-- **Object Merging**: If the attribute type is an object, it will be merged recursively. If there are attributes with the same key within the object, the value in the original JSON will be directly overwritten.
+- **Array Elements**: If the property type is an array, each value in the array will be merged according to element order. If a value in the array is an object, it will be merged recursively. If a value in the array is a primitive type, it will directly overwrite the value in the original JSON.
+- **Object Merging**: If the property type is an object, it will be merged recursively. If there are attributes with the same key within the object, the value in the original JSON will be directly overwritten.
 - **Primitive Attributes**: For primitive attributes with the same key, they are directly overwritten, i.e., replacing the value in the original JSON.
 
-For other fields, such as `SEEDCHOOSERDEFAULTORDER`/`BASEUNLOCKLIST`, the original array is directly replaced.
+For other properties, such as `SEEDCHOOSERDEFAULTORDER`/`BASEUNLOCKLIST`, the original array is simply replaced.
 
-Therefore, for any plant/zombie that needs modification, you must add an object to the `PLANTS` (`ZOMBIES`) array, and the `CODENAME` field of this object must match the original plant/zombie in the JSON. For plants/zombies that do not need modification, this object does not need to be added.
+Therefore, for any plant/zombie that needs modification, you must add an object to the `PLANTS` (or `ZOMBIES`) array, and the `CODENAME` field of this object must match the original plant/zombie in the JSON. For plants/zombies that do not need modification, this object does not need to be added.
 
 Within a single plant/zombie object, only the `CODENAME` needs to be filled. Other fields not filled will remain unchanged. If modification is needed, the corresponding fields must be added.
 
 > [!important]
 >
-> - Avoid modifying critical fields like `ID` or `_CARDSPRITENAME` to prevent crashes.。
-> - **GE Patcher cannot create new entities; it only modifies existing ones.**
+> - Avoid modifying critical properties like `ID` or `_CARDSPRITENAME` to prevent crashes or other unwanted bugs.
+> - **GE Patcher cannot create new plants, zombies, or anything like; it only modifies existing entities.**
 
 **Example**
 
@@ -181,9 +171,9 @@ To change the Peashooter's background to "epic" and the Sunflower's name to "Hap
 
 ### Props File Structure
 
-Props files contain the numerical attributes of plants and zombies. The file structure is as follows:
+Props files contain the gameplay properties of plants and zombies. The file structure is as follows:
 
-**PlantProps.json**：Plant numerical attributes (structure example)
+**PlantProps.json**
 
 ```json
 {
@@ -206,7 +196,7 @@ Props files contain the numerical attributes of plants and zombies. The file str
 }
 ```
 
-**ZombieProps.json**：Zombie numerical attributes (structure example)
+**ZombieProps.json**
 
 ```json
 {
@@ -228,16 +218,16 @@ Props files contain the numerical attributes of plants and zombies. The file str
 
 **Key Notes**
 
-- The `objects` array defines modifications to existing plants/zombies.
-- The `aliases` array indicates which plant/zombie the object belongs to. Currently, GE Patcher only reads the first item of this array.
-- The `objclass` indicates the type of the object, and its value must be `PlantProperties` or `ZombieProperties`.
-- `objdata` contains the numerical attributes of the plant/zombie.
+- The `objects` array defines the objects that modify existing plants/zombies.
+- The `aliases` array indicates which plant/zombie the object belongs to. Right now, GE Patcher only reads the first item of this array.
+- The `objclass` indicates the type of the object, and its value must be `PlantProperties` or `ZombieProperties` depending on what you're modifying.
+- `objdata` contains the gameplay properties of the plant/zombie.
 
 ### Almanac File Structure
 
 Almanac files contain the Almanac information for plants and zombies. The file structure is as follows:
 
-**PlantAlmanac.json**：Plant Almanac information (structure example)
+**PlantAlmanac.json**
 
 ```json
 {
@@ -294,7 +284,7 @@ Almanac files contain the Almanac information for plants and zombies. The file s
 }
 ```
 
-**ZombieAlmanac.json**：Zombie Almanac information (structure example)
+**ZombieAlmanac.json**
 
 ```json
 {
@@ -347,16 +337,16 @@ Almanac files contain the Almanac information for plants and zombies. The file s
 
 Props modification rules apply to `PlantProps` and `ZombieProps` files. Almanac modification rules apply to `PlantAlmanac` and `ZombieAlmanac` files.
 
-Each object in the `objects` array is merged into the original JSON after being matched by the `aliases` field, using the same rules as for `Features` files.
+Each object in the `objects` array is merged into the original JSON after being matched by the `aliases` field, using the same rules as for the `Features` files.
 
-For any plant/zombie that needs modification, you must add an object to the `objects` array, and the first item of that object's `aliases` array must be the `CODENAME` of the corresponding plant/zombie.
-For plants/zombies that do not need modification, this object does not need to be added.
+For any plant/zombie you want to modify, you must add an object to the `objects` array. That object must have an `aliases` property with the plant/zombie you want to modify's codename.
+For plants/zombies that you don't want to change, you don't need to do anything - it'll default to vanilla properties.
 
-Within a single object, `objdata` contains the numerical attributes or Almanac information of the plant/zombie. Only the attributes that need to be modified should be filled. Attributes not filled will remain unchanged.
+Within a single object, `objdata` contains the gameplay properties or Almanac information of the plant/zombie. Only the properties that need to be modified should be added. Properties not added will default to vanilla properties.
 
 > [!important]
 >
-> - `Almanac` files are only used to modify the Almanac information of plants/zombies and do not affect the actual attributes of the plants.
+> - `Almanac` files are only used to modify the Almanac information of plants/zombies and do not affect the actual in-game stats of the plants.
 > - Array attributes in `objdata`, such as `Elements` in `Almanac` files, will be merged according to element order. To modify the value of an item in the original array, you need to make the modification at the same position in the array.
 
 ## Level Files
@@ -365,6 +355,7 @@ Place custom level files in `patches/jsons/levels/[LevelName].json`.
 
 - Filenames must match the in-game level ID (e.g., `egypt1.json`).
 - Use `gePatcher.showLevels()` to view original level IDs (requires initializing GE Patcher first).
+- JSON5 levels are not supported and will not load.
 
 ## Store Files
 
@@ -378,6 +369,7 @@ Place custom level files in `patches/jsons/levels/[LevelName].json`.
   "Coin": [] // Coin items (purchased with gems)
 }
 ```
+_Note: comments are supported in JSON._
 
 Omit categories you do not modify.
 
@@ -387,4 +379,4 @@ Omit categories you do not modify.
 2. Common errors:
    - ❌ `Failed to load...`: JSON syntax error.
    - ❌ `Level file not found`: Filename mismatch.
-3. Validate JSON using tools like [JSONLint](https://jsonlint.com/).
+3. Validate JSONs with tools like [JSONLint](https://jsonlint.com/).

--- a/src/en/guide/mod/patcher.md
+++ b/src/en/guide/mod/patcher.md
@@ -70,7 +70,7 @@ patches/
 
 The `features` directory contains `Features`, `Props`, and `Almanac` files for modifying plants, zombies, upgrades, the shop, etc.
 
-Files under the `levels` directory are used to replace levels. If you want to get the original levels, try to find similar ones in vanilla PvZ2 (extracting PvZ2 files are out of the scope of this guide).
+Files under the `levels` directory are used to replace levels. If you want to get the original levels, try to find similar ones in vanilla PvZ2 (extracting PvZ2 files is out of the scope of this guide).
 
 Anything you don't modify will default to the base-game properties.
 

--- a/src/en/guide/mod/patcher.md
+++ b/src/en/guide/mod/patcher.md
@@ -339,8 +339,9 @@ Props modification rules apply to `PlantProps` and `ZombieProps` files. Almanac 
 
 Each object in the `objects` array is merged into the original JSON after being matched by the `aliases` field, using the same rules as for the `Features` files.
 
-For any plant/zombie you want to modify, you must add an object to the `objects` array. That object must have an `aliases` property with the plant/zombie you want to modify's codename.
-For plants/zombies that you don't want to change, you don't need to do anything - it'll default to vanilla properties.
++For any plant/zombie you want to modify, you must add an object to the `objects` array. That object must have an `aliases` property with the plant/zombie you want to modify's codename.
++**Note:** Only the first element of the `aliases` array is used to match the plant/zombie for modification.
++For plants/zombies that you don't want to change, you don't need to do anything - it'll default to vanilla properties.
 
 Within a single object, `objdata` contains the gameplay properties or Almanac information of the plant/zombie. Only the properties that need to be modified should be added. Properties not added will default to vanilla properties.
 

--- a/src/en/guide/mod/patcher.md
+++ b/src/en/guide/mod/patcher.md
@@ -1,5 +1,5 @@
 ---
-title: GE Patcher Tutorial(latest)
+title: GE Patcher Tutorial (latest)
 icon: wrench
 pageInfo: false
 index: true


### PR DESCRIPTION
A couple things to note:

1. No Chinese translation
2. Old pages weren't updated

Obviously, you can change anything you want here; I just thought I'd propose a little tweak.

好的，这是对 pull request 总结的中文翻译：

## Sourcery 总结

改进并标准化 GE Patcher 的 Modding 教程和属性参考文档。

增强功能：
- 重命名教程和参考标题，以保持一致性。
- 在所有章节中使用“属性 (properties)”术语来代替“特性 (attributes)”。
- 提高控制台命令和重新加载步骤的清晰度 (`F12`, `gePatcher.init()`, `gePatcher.help()`)。
- 阐明 GE Patcher 目录路径和 PC 构建包含。
- 添加关于关卡文件中不支持 JSON5 以及 JSON 存储文件中支持注释的说明。
- 更新 features、props 和 almanac 文件的合并规则描述。
- 润色语法、措辞、内联代码格式、标题和表格列标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine and standardize the modding tutorial and properties reference documentation for GE Patcher.

Enhancements:
- Rename tutorial and reference titles for consistency.
- Adopt “properties” terminology in place of “attributes” across all sections.
- Improve clarity of console commands and reloading steps (`F12`, `gePatcher.init()`, `gePatcher.help()`).
- Clarify GE Patcher directory path and PC build inclusion.
- Add notes on unsupported JSON5 in level files and support for comments in JSON store files.
- Update merging rule descriptions for features, props, and almanac files.
- Polish grammar, wording, inline code formatting, headings, and table column labels.

</details>