### PR TITLE
docs: improve modding tutorial with clearer instructions (#32)

### DIFF
--- a/src/en/guide/mod/README.md
+++ b/src/en/guide/mod/README.md
@@ -1,5 +1,5 @@
 ---
-title: MOD tutorial
+title: MOD Tutorial
 index: true
 icon: toolbox
 pageInfo: false
@@ -15,9 +15,116 @@ onMounted(() => {
 })
 </script>
 
-> [!tip]
-> Starting from version `0.2.8.1`, PvZ2 Gardendless supports partial Patch functionality. You can use the built-in GE Patcher in the game to modify JSON files to customize plants, zombies, the store, and levels. This feature is not available in the online version.
->
-> The development team does not guarantee that this feature will be supported in future versions, which depends on the game's updates and maintenance.
+## Overview
+
+Starting from version `0.2.8.1`, PvZ2 Gardendless supports modding through **GE Patcher** - a built-in tool that lets you customize the game by modifying JSON files.
+
+> [!warning]
+> Modding is only available in the **desktop version** (Windows/Linux/Mac via Docker). The online web version does not support mods.
+
+## What Can You Mod?
+
+| Category | Examples | Difficulty |
+|----------|----------|------------|
+| **Plant Stats** | Sun cost, damage, cooldown, health | Easy |
+| **Zombie Stats** | Health, speed, damage | Easy |
+| **Store Items** | Prices, currency type, unlock requirements | Easy |
+| **Levels** | Zombie waves, sun production, layout | Medium |
+| **Almanac** | Descriptions, display info | Easy |
+| **Projectiles** | Damage, behavior | Medium |
+
+## What You CANNOT Mod
+
+- ❌ Add new plants or zombies
+- ❌ Add new worlds
+- ❌ Modify core game mechanics
+- ❌ Change graphics/sprites
+- ❌ Add new music/sounds
+
+## Quick Start
+
+### Step 1: Find Your Game Directory
+
+Open the game, press **F12** to open Developer Console, and look for:
+
+```text
+[GE Patcher] BaseDir: C:\Users\YourName\AppData\Local\com.pvzge.app
+```
+
+### Step 2: Create Patches Folder
+
+Navigate to that directory and create this structure:
+
+```
+com.pvzge.app/
+└── patches/
+    └── jsons/
+        ├── features/      ← Plant/zombie modifications
+        └── levels/        ← Level modifications
+```
+
+### Step 3: Create Your First Mod
+
+Create `patches/jsons/features/PlantProps.json`:
+
+```json
+{
+  "objects": [
+    {
+      "aliases": ["peashooter"],
+      "objclass": "PlantProperties",
+      "objdata": {
+        "SunCost": 50,
+        "Damage": 40
+      }
+    }
+  ]
+}
+```
+
+This makes Peashooter cost 50 sun and deal double damage.
+
+### Step 4: Load Your Mod
+
+In the game console (F12), run:
+
+```javascript
+gePatcher.init()
+```
+
+Your mod is now active!
+
+## Tutorials
 
 <Catalog />
+
+## Troubleshooting
+
+### Mod not loading?
+
+1. Check file path is correct (must be in `patches/jsons/`)
+2. Validate JSON syntax at [jsonlint.com](https://jsonlint.com/)
+3. Run `gePatcher.help()` to verify patch directory
+4. Make sure game is fully loaded before running `gePatcher.init()`
+
+### Changes not appearing?
+
+Run `gePatcher.initPatchs()` again after editing JSON files.
+
+### Game crashes after mod?
+
+1. Remove your mod files
+2. Run `gePatcher.restoreAll()` in console
+3. Check console (F12) for error messages
+4. Verify your JSON structure matches the expected format
+
+### Need reference data?
+
+Export original game data to see the correct format:
+
+```javascript
+gePatcher.exportJson('PlantProps', true)
+```
+
+> [!tip]
+> The development team does not guarantee modding support in future versions. Mods may break after game updates.

--- a/src/en/guide/mod/format.md
+++ b/src/en/guide/mod/format.md
@@ -7,17 +7,19 @@ order: 2
 ---
 
 <script setup>
-    import { onMounted } from 'vue';
-    onMounted(() => {
-        (window.adsbygoogle = window.adsbygoogle || []).push({});
-    })
+    import { onMounted } from 'vue';
+    onMounted(() => {
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+    })
 </script>
 
 > [!warning]
-> The following tutorial only works for versions `0.3.X`-`0.6.X`.
+> This reference applies to versions `0.3.X` - `0.6.X`.
+
+This page documents all modifiable properties for plants, zombies, and store items. Use this as a reference when creating your mod files.
 
 > [!important]
-> In the tables, properties in _italics_ are properties that you probably shouldn't modify. Modifying them may cause the game to crash or bug out.
+> Properties in *italics* are **dangerous to modify** - changing them may crash the game or cause unexpected behavior.
 
 <ins class="adsbygoogle"
      style="display:block"
@@ -27,97 +29,214 @@ order: 2
      data-full-width-responsive="true">
 </ins>
 
+## Quick Reference
+
+| File | What It Modifies | Match By |
+|------|------------------|----------|
+| `PlantFeatures.json` | Plant metadata, unlock order | `CODENAME` |
+| `PlantProps.json` | Plant stats (damage, cost, cooldown) | `aliases` |
+| `PlantAlmanac.json` | Almanac display text | `aliases` |
+| `ZombieFeatures.json` | Zombie metadata | `CODENAME` |
+| `ZombieProps.json` | Zombie stats | `aliases` |
+| `ZombieAlmanac.json` | Almanac display text | `aliases` |
+| `StoreCommodityFeatures.json` | Shop items and prices | category arrays |
+
+---
+
 ## Plant Files
-
-Below is the format of the plant JSON files, using Grapeshot as an example.
-
-Properties with multilingual values cannot be deleted or have extra fields added. The format must be as follows:
-
-```json
-{
-  "en": "English",
-  "zh": "中文"
-}
-```
 
 ### PlantFeatures.json
 
-The PlantFeatures.json file contains the basic characteristics of plants.
+Controls plant metadata and unlock order.
 
-Each plant in the `PLANTS` array includes the following properties:
+**Structure:**
 
-| Property           | Example Content                           | Description                                                                                            |
-| ------------------ | ----------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **ID**             | 74                                        | Unique ID value of the plant in the game                                                               |
-| **NAME**           | `{ "en": "Grapeshot", "zh": "爆裂葡萄" }` | Multilingual name, `en` for English name, `zh` for Chinese name                                        |
-| _\_CARDSPRITENAME_ | "grapeshot"                               | Card icon resource name (corresponding to game resource files)                                         |
-| _CODENAME_         | "grapeshot"                               | Unique identifier for the plant (critical field, used for GE Patcher merging)                          |
-| _TYPE_             | `["plant", "lastStandDisallowed"]`        | Plant type:<br>- `plant`: Normal plant<br>- `lastStandDisallowed`: Cannot be used in "Last Stand" mode |
-| **OBTAINWORLD**    | "market"                                  | The world where the background image is located                                                        |
-| **ZENGARDEN**      | `{ "PlantPlace": "dirt" }`                | Zen Garden planting location:<br>- `dirt`: Normal soil                                                 |
-| _COSTUME_          | 2                                         | Number of costumes                                                                                     |
+```json
+{
+  "PLANTS": [
+    { "CODENAME": "peashooter", ... }
+  ],
+  "SEEDCHOOSERDEFAULTORDER": ["peashooter", "sunflower"],
+  "BASEUNLOCKLIST": ["peashooter", "sunflower"]
+}
+```
 
-The `SEEDCHOOSERDEFAULTORDER` array is used to specify the default order of plants in the selection interface. It should only have plants' `CODENAME` and the order they are in the array is the order they will appear in the almanac, seed chooser, etc.
+**PLANTS Array Properties:**
 
-The `BASEUNLOCKLIST` array contains plants newly created player profiles have by default. It also uses plants' `CODENAME`.
+| Property | Example | Description | Safe to Modify? |
+|----------|---------|-------------|-----------------|
+| *ID* | `74` | Unique plant ID | ⚠️ No |
+| **NAME** | `{"en": "Grapeshot", "zh": "爆裂葡萄"}` | Display name | ✅ Yes |
+| *_CARDSPRITENAME* | `"grapeshot"` | Card sprite resource | ⚠️ No |
+| *CODENAME* | `"grapeshot"` | Unique identifier | ⚠️ No |
+| *TYPE* | `["plant", "lastStandDisallowed"]` | Plant type flags | ⚠️ Careful |
+| **OBTAINWORLD** | `"market"` | Background image world | ✅ Yes |
+| **ZENGARDEN** | `{"PlantPlace": "dirt"}` | Zen Garden placement | ✅ Yes |
+| *COSTUME* | `2` | Number of costumes | ⚠️ Careful |
 
-### PlantAlmanac.json
+**Special Arrays:**
 
-The PlantAlmanac.json file contains the Almanac information for plants.
+| Array | Purpose | Notes |
+|-------|---------|-------|
+| `SEEDCHOOSERDEFAULTORDER` | Order in seed chooser | Uses `CODENAME` values |
+| `BASEUNLOCKLIST` | Plants unlocked for new players | Uses `CODENAME` values |
 
-Each item in the `objects` array should include `aliases`, `objclass`, and `objdata`, or else it may not change in-game.
-
-The `aliases` array contains the plant's `CODENAME`, used to indicate the corresponding plant for this object. Only the first item is read from at the moment. The value of `objclass` is `PlantAlmanacProperties`, indicating that this object modifies a plant almanac entry.
-
-`objdata` includes the following Almanac properties:
-
-| Property              | Value/Content                                                                                                                                                     | Description                                              |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| _Elements_            | Contains multiple properties:<br>- `SUNCOST`:Sun cost<br>- `RECHARGE`:Cooldown<br>- `DAMAGE`:Damage value (1800)<br>- `AREA`:Range (3x3)<br>- `FAMILY`:Family | Key property  tags shown in Almanac                      |
-| **Introduction**      | `{ "en": "...", "zh": "爆炸后向 8 个方向发射弹性葡萄子弹" }`                                                                                                      | Multilingual description of plant function               |
-| _Special_             | `{ "NAME": {"en":"...","zh":"..."}, "DESCRIPTION": {"en":"...","zh":"..."} }`                                                                                     | Special mechanism description                            |
-| **Chat**              | `{"en":"...","zh":"..."}`                                                                                                                                         | Multilingual, plant's personality lines                  |
-| **BriefIntroduction** | `{ "en": "Explodes...", "zh": "爆炸并发射弹射子弹" }`                                                                                                             | Multilingual, brief function summary                     |
-| **DisplayOffset**     | `{ "x": 0, "y": 0 }`                                                                                                                                              | Display position offset (adjusts coordinates in Almanac) |
+---
 
 ### PlantProps.json
 
-The PlantProps.json file contains gameplay properties of plants.
+Controls plant gameplay stats.
 
-Each item in the `objects` array includes `aliases`, `objclass`, and `objdata`, just like in `PlantAlmanac.json`.
+**Structure:**
 
-The `aliases` array contains the plant's `CODENAME`, used to indicate the corresponding plant for this object. Again, only the first entry is read. The value of `objclass` is `PlantProperties`, indicating that this object modifies a plant's gameplay properties.
+```json
+{
+  "objects": [
+    {
+      "aliases": ["peashooter"],
+      "objclass": "PlantProperties",
+      "objdata": {
+        "SunCost": 100,
+        "Damage": 20
+      }
+    }
+  ]
+}
+```
 
-`objdata` includes the following properties, but some plants have properties others don't. Valid properties for each plant can be viewed in the [Almanac](../../almanac/).
+**Common Properties:**
 
-| Property                      | Value/Content | Description                                             |
-| ----------------------------- | ------------- | ------------------------------------------------------- |
-| **CannotBeSheepenedByWizard** | true          | Immune to Wizard Zombie's "sheep transformation" skill  |
-| **Damage**                    | 1800          | Base damage value                                       |
-| **Cooldown**                  | 35            | Cooldown time (unit: seconds)                           |
-| **CooldownFrom**              | 1             | Cooldown start time (represents initial cooldown value) |
-| **SunCost**                   | 150           | Sun required for planting                               |
-| **Toughness**                 | 300           | Base plant health points                                |
-| **Family**                    | "Explosive"   | Family (may affect family bonus effects)                |
-| **ImmuneToIceblock**          | true          | Immune to freezing effects (e.g., Ice Weasel Zombie)    |
+| Property | Type | Example | Description |
+|----------|------|---------|-------------|
+| **SunCost** | number | `100` | Sun required to plant |
+| **Damage** | number | `20` | Base damage per hit |
+| **Cooldown** | number | `5` | Recharge time (seconds) |
+| **CooldownFrom** | number | `1` | Initial cooldown value |
+| **Toughness** | number | `300` | Plant health points |
+| **Family** | string | `"Explosive"` | Plant family name |
+| **ShootInterval** | number | `1.35` | Time between shots |
+| **PlantfoodPeaCount** | number | `60` | Projectiles in plant food attack |
+
+**Immunity Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| **CannotBeSheepenedByWizard** | boolean | Immune to Wizard transformation |
+| **ImmuneToIceblock** | boolean | Immune to freezing |
+
+> [!tip]
+> Not all plants have all properties. Export original data to see which properties each plant uses:
+> ```javascript
+> gePatcher.exportJson('PlantProps', true)
+> ```
+
+---
+
+### PlantAlmanac.json
+
+Controls Almanac display information (cosmetic only - doesn't affect gameplay).
+
+**Structure:**
+
+```json
+{
+  "objects": [
+    {
+      "aliases": ["peashooter"],
+      "objclass": "PlantAlmanacProperties",
+      "objdata": {
+        "Introduction": {"en": "...", "zh": "..."},
+        "Chat": {"en": "...", "zh": "..."}
+      }
+    }
+  ]
+}
+```
+
+**Properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| *Elements* | array | Stat tags shown in Almanac |
+| **Introduction** | multilingual | Plant description |
+| *Special* | object | Special ability description |
+| **Chat** | multilingual | Plant personality quote |
+| **BriefIntroduction** | multilingual | Short summary |
+| **DisplayOffset** | `{x, y}` | Position adjustment in Almanac |
+
+**Elements Array Types:**
+
+| TYPE | Description |
+|------|-------------|
+| `SUNCOST` | Shows sun cost |
+| `RECHARGE` | Shows cooldown |
+| `DAMAGE` | Shows damage value |
+| `AREA` | Shows attack range |
+| `FAMILY` | Shows plant family |
+
+---
+
+## Zombie Files
+
+### ZombieFeatures.json
+
+Controls zombie metadata.
+
+**Structure:**
+
+```json
+{
+  "ZOMBIES": [
+    { "CODENAME": "tutorial", ... }
+  ]
+}
+```
+
+Works the same as `PlantFeatures.json` but for zombies.
+
+### ZombieProps.json
+
+Controls zombie gameplay stats.
+
+**Structure:**
+
+```json
+{
+  "objects": [
+    {
+      "aliases": ["tutorial"],
+      "objclass": "ZombieProperties",
+      "objdata": {
+        "Toughness": 200,
+        "WalkSpeed": 0.5
+      }
+    }
+  ]
+}
+```
+
+---
 
 ## Store Files
 
-The `StoreCommodityFeatures.json` file contains store commodity information, including four arrays: `Plants`, `Upgrade`, `Gem`, and `Coin`, representing different types of commodity information.
+### StoreCommodityFeatures.json
 
-### Plants
+Controls shop items and prices.
 
-The `Plants` array contains information about plant commodities.
+**Structure:**
 
-| Property             | Type   | Description                     |
-| -------------------- | ------ | ------------------------------- |
-| _CommodityType_      | string | Fixed value "plant"             |
-| **CommodityName**    | string | Plant's CODENAME                |
-| **CurrencyType**     | string | Currency type ("gem" or "coin") |
-| **CurrencyRequired** | number | Amount of currency required     |
-| _UnlockLevel_        | string | Unlocks at a certain level      |
+```json
+{
+  "Plants": [...],
+  "Upgrade": [...],
+  "Gem": [...],
+  "Coin": [...]
+}
+```
 
-**Example: Snow Pea Commodity**
+Only include categories you want to modify.
+
+### Plants Category
 
 ```json
 {
@@ -128,18 +247,15 @@ The `Plants` array contains information about plant commodities.
 }
 ```
 
-### Upgrade
+| Property | Type | Description |
+|----------|------|-------------|
+| *CommodityType* | string | Always `"plant"` |
+| **CommodityName** | string | Plant's CODENAME |
+| **CurrencyType** | string | `"gem"` or `"coin"` |
+| **CurrencyRequired** | number | Price |
+| *UnlockLevel* | string | Level required to unlock |
 
-The `Upgrade` array contains information about plant upgrade commodities.
-
-| Property             | Type   | Description                     |
-| -------------------- | ------ | ------------------------------- |
-| _CommodityType_      | string | Fixed value "upgrade"           |
-| **CommodityName**    | string | CODENAME of the upgrade item    |
-| **CurrencyType**     | string | Currency type ("gem" or "coin") |
-| **CurrencyRequired** | number | Amount of currency required     |
-
-**Example: Shovel Upgrade**
+### Upgrade Category
 
 ```json
 {
@@ -150,20 +266,7 @@ The `Upgrade` array contains information about plant upgrade commodities.
 }
 ```
 
-### Gem
-
-The `Gem` array contains information about Gem commodities.
-
-| Property                 | Description                           |
-| ------------------------ | ------------------------------------- |
-| _CommodityType_          | Fixed value "gem"                     |
-| CommodityCount           | Amount of Gems obtained               |
-| **CurrencyType**         | Currency type ("gem" or "coin")       |
-| CurrencyRequired         | Amount of currency required           |
-| _StackLevel_             | Commodity pack level                  |
-| **CommodityDisplayName** | Commodity display name (multilingual) |
-
-**Example: Adjusting a Gem Pack**
+### Gem/Coin Categories
 
 ```json
 {
@@ -172,22 +275,22 @@ The `Gem` array contains information about Gem commodities.
   "CurrencyType": "coin",
   "CurrencyRequired": 300000,
   "StackLevel": 4,
-  "CommodityDisplayName": {
-    "en": "Ultimate Gem Pack!",
-    "zh": "终极钻石包！"
-  }
+  "CommodityDisplayName": {"en": "Gem Pack", "zh": "钻石包"}
 }
 ```
 
-### Coin
+---
 
-The `Coin` array contains information about Coin commodities.
+## Multilingual Format
 
-| Property                 | Description                           |
-| ------------------------ | ------------------------------------- |
-| _CommodityType_          | Fixed value "coin"                    |
-| CommodityCount           | Amount of Coins obtained              |
-| **CurrencyType**         | Currency type ("gem" or "coin")       |
-| CurrencyRequired         | Amount of currency required           |
-| _StackLevel_             | Commodity pack level                  |
-| **CommodityDisplayName** | Commodity display name (multilingual) |
+All text properties that support multiple languages use this format:
+
+```json
+{
+  "en": "English text",
+  "zh": "中文文本"
+}
+```
+
+> [!warning]
+> Do not add or remove language keys - only modify existing values.

--- a/src/en/guide/mod/patcher.md
+++ b/src/en/guide/mod/patcher.md
@@ -14,17 +14,17 @@ order: 1
 </script>
 
 > [!warning]
-> The following tutorial applies only to versions `0.3.X`-`0.6.X`.
+> This tutorial applies to versions `0.3.X` - `0.6.X`.
 
-GE Patcher is a tool used to modify game data for PvZ2 Gardendless, supporting custom modifications for plants, zombies, grid items (GridItem), projectiles (Projectile), upgrades, store commodities, and levels.
-
-It is recommended to use the built-in version of GE Patcher (included in the official release).
+GE Patcher is the built-in modding tool for PvZ2 Gardendless. It allows you to customize plants, zombies, projectiles, upgrades, store items, and levels by editing JSON files.
 
 ## Prerequisites
 
-1. JSON Editor (VSCode/Notepad++ recommended)
-2. Game Version ≥ 0.3.0
-3. For JSON property structures of plants, zombies, etc., please refer to [Property Reference](format.md)
+Before you start:
+
+- **JSON Editor**: [VS Code](https://code.visualstudio.com/) (recommended) or Notepad++
+- **Game Version**: 0.3.0 or higher
+- **Basic JSON knowledge**: Understanding of JSON syntax (objects, arrays, key-value pairs)
 
 <ins class="adsbygoogle"
 style="display:block"
@@ -34,156 +34,145 @@ data-ad-format="auto"
 data-full-width-responsive="true">
 </ins>
 
-## GE Patcher Basics
+## Step 1: Find Your Patch Directory
 
-Open the developer interface by pressing "F12" when the game starts. In the Console tab, you will see output similar to the following:
+1. Launch the game
+2. Press **F12** to open Developer Console
+3. Look for this line:
 
 ```text
-[GE Patcher] BaseDir: C:\Users\admin\AppData\Local\com.pvzge.app
+[GE Patcher] BaseDir: C:\Users\YourName\AppData\Local\com.pvzge.app
 ```
 
-The path above is the main directory for GE Patcher (example). Run the following command in the console to view help information and output the patches directory:
+4. Run `gePatcher.help()` for more info and to confirm the patches directory
 
-```javascript
-gePatcher.help()
+> [!tip]
+> **Common Locations:**
+> - Windows: `C:\Users\YourName\AppData\Local\com.pvzge.app`
+> - Mac (Docker): Check Docker container logs
+> - Linux (Docker): Check Docker container logs
+
+## Step 2: Create Folder Structure
+
+Navigate to your BaseDir and create this structure:
+
+```
+com.pvzge.app/
+└── patches/
+    └── jsons/
+        ├── features/           ← Entity metadata (plants, zombies, etc.)
+        │   ├── PlantFeatures.json
+        │   ├── PlantProps.json
+        │   ├── PlantAlmanac.json
+        │   ├── ZombieFeatures.json
+        │   ├── ZombieProps.json
+        │   └── ... (more files)
+        └── levels/             ← Custom level files
+            └── egypt1.json     ← Filename = level ID
 ```
 
-GE Patcher also automatically loads the cloud save module (`window.cloudSaver`).
+> [!important]
+> Only create files you need to modify. Empty or unchanged files are not required.
 
-After the game finishes loading, run the following commands to load/apply patches:
+## Step 3: Load and Apply Patches
+
+After the game **fully loads** (you see the main menu), run commands in the console:
 
 ```javascript
-// Load base assets, does not load patch files
-gePatcher.initBase()
-
-// After calling initBase, you can call initPatchs() to load patch files
-// Call this function again to apply changes after modifying JSON files
-gePatcher.initPatchs()
-
-// Load both base assets and patch files, equivalent to combining the two steps above
+// Option 1: Load everything at once (recommended)
 gePatcher.init()
+
+// Option 2: Load in steps
+gePatcher.initBase()    // Load base assets first
+gePatcher.initPatchs()  // Then load your patches
 ```
 
-Other common function examples:
+> [!warning]
+> Always wait for the game to fully load before running these commands. Running too early will cause errors.
+
+## Step 4: Reload After Changes
+
+After editing your JSON files:
 
 ```javascript
-// List original level IDs in the game
+// Reload patches without restarting the game
+gePatcher.initPatchs()
+```
+
+## Useful Commands Reference
+
+### View Available Data
+
+```javascript
+// List all level IDs in the game
 gePatcher.showLevels()
 
-// Set custom frame rate (dangerous operation, may cause crashes or performance issues)
+// List saved original JSON data
+gePatcher.listOrigins()
+```
+
+### Export Original Data (for reference)
+
+```javascript
+// Export to console (view structure)
+gePatcher.exportJson('PlantProps', true)
+
+// Export and download as file
+gePatcher.exportJson('PlantProps', true, true)
+
+// Available data types:
+// PlantFeatures, PlantProps, PlantAlmanac, PlantTypes
+// ZombieFeatures, ZombieProps, ZombieAlmanac, ZombieTypes
+// ProjectileProps, ProjectileTypes, UpgradeFeatures
+// StoreCommodityFeatures, NarrativeList, PropertySheets
+```
+
+### Quick Modifications (without JSON files)
+
+```javascript
+// Modify a single property
+gePatcher.setPropsData('PlantProps', 'peashooter', 'SunCost', 50)
+
+// Modify multiple properties at once
+gePatcher.setPropsData('PlantProps', 'peashooter', {
+  SunCost: 50,
+  Damage: 40,
+  Cooldown: 3
+})
+```
+
+### Restore Original Data
+
+```javascript
+// Restore a specific data type
+gePatcher.restoreOriginal('PlantFeatures')
+
+// Restore everything to original
+gePatcher.restoreAll()
+```
+
+### Advanced
+
+```javascript
+// Set custom frame rate (use with caution!)
 gePatcher.setFrameRate(30)
-
-// Modify a single property of a single entity (example)
-gePatcher.setPropsData('PlantProps', 'peashooter', 'ShootInterval', 1.2)
-
-// Merge multiple properties (pass an object)
-gePatcher.setPropsData('PlantProps', 'peashooter', { ShootInterval: 1.2, SunCost: 75 })
-
-// Data management and export
-gePatcher.listOrigins()             // List saved original JSON data
-gePatcher.exportJson('PlantFeatures', false) // Export current PlantFeatures data (second arg true exports original JSON, third arg true downloads file, false outputs to console)
-gePatcher.restoreOriginal('PlantFeatures')   // Restore PlantFeatures to original JSON data
-gePatcher.restoreAll()              // Restore all data
 ```
 
-## File Structure
+## File Types Explained
 
-Create a `patches` folder under `com.pvzge.app` with the following structure:
+| File | Purpose | Key Field |
+|------|---------|-----------|
+| `*Features.json` | Entity metadata, unlock order | `CODENAME` |
+| `*Props.json` | Gameplay stats (damage, cost, etc.) | `aliases` |
+| `*Almanac.json` | Almanac display info | `aliases` |
+| `*Types.json` | Type definitions | varies |
+| `levels/*.json` | Level wave data | filename |
 
-```
-patches/
-└── jsons/
-    ├── features/
-    │   ├── PlantFeatures.json
-    │   ├── PlantProps.json
-    │   ├── PlantAlmanac.json
-    │   ├── PlantTypes.json
-    │   ├── ZombieFeatures.json
-    │   ├── ZombieProps.json
-    │   ├── ZombieAlmanac.json
-    │   ├── ZombieTypes.json
-    │   ├── BoardGridMaps.json
-    │   ├── ProjectileProps.json
-    │   ├── ProjectileTypes.json
-    │   ├── UpgradeFeatures.json
-    │   ├── PropertySheets.json
-    │   ├── NarrativeList.json
-    │   └── StoreCommodityFeatures.json
-    └── levels/
-        └── [LevelName].json
-```
+## Example: Modify Peashooter
 
-Description:
+### Goal: Make Peashooter cheaper and stronger
 
-- The `features` directory contains various Features/Props/Types/Almanac files for modifying metadata and behavior of game entities.
-- Files for modifying original content do not need to be created if unchanged.
-
-## Features Files
-
-Features files are used for merging metadata modifications for entities (plants, zombies, grid items, upgrades, etc.).
-
-### Common Features Examples
-
-**PlantFeatures.json** (Example):
-
-```json
-{
-  "PLANTS": [
-    {
-      "CODENAME": "peashooter"
-    }
-  ],
-  "SEEDCHOOSERDEFAULTORDER": ["peashooter", "sunflower"],
-  "BASEUNLOCKLIST": ["peashooter", "sunflower"]
-}
-```
-
-**ZombieFeatures.json** (Example):
-
-```json
-{
-  "ZOMBIES": [
-    {
-      "CODENAME": "tutorial"
-    }
-  ]
-}
-```
-
-**UpgradeFeatures.json** (Example):
-
-```json
-{
-  "UPGRADES": [
-    {
-      "CODENAME": "upgrade_starting_sun_lvl1"
-    }
-  ]
-}
-```
-
-**GridItemFeatures.json / StoreCommodityFeatures.json**, etc., have similar structures, providing the CODENAME/Identifier of the item to be modified according to the original game structure.
-
-### Features Merging Rules (Summary)
-
-- Match existing entities by CODENAME (or corresponding identifier), then merge the user-provided object with the original object.
-- Primitive type fields are overwritten directly; object types are merged recursively; array types are merged by element order (if array elements are primitive types, they are overwritten).
-- For top-level array fields like `SEEDCHOOSERDEFAULTORDER`, `BASEUNLOCKLIST`, the original array will be replaced directly.
-
-Important: GE Patcher only modifies existing entities and does not create brand new entity entries. Try to avoid modifying key identifiers (e.g., `ID`, `_CARDSPRITENAME`, etc.).
-
-## Props / Almanac / Types Files
-
-These files are used to modify specific numerical values, almanac information, or type tables for entities:
-
-- `PlantProps.json` / `ZombieProps.json`: Modify numerical properties (`PlantProperties` / `ZombieProperties`).
-- `PlantAlmanac.json` / `ZombieAlmanac.json`: Modify almanac display information (does not change actual combat stats).
-- `PlantTypes.json` / `ZombieTypes.json`: Define type data for plants/zombies.
-- `ProjectileProps.json` / `ProjectileTypes.json`: Projectile/bullet related properties and type definitions.
-- `NarrativeList.json`: Modify storyline dialogue lists.
-- `PropertySheets.json`: Overwrite or supplement certain property sheets.
-
-### Props File Example (PlantProps.json)
+**File: `patches/jsons/features/PlantProps.json`**
 
 ```json
 {
@@ -192,76 +181,109 @@ These files are used to modify specific numerical values, almanac information, o
       "aliases": ["peashooter"],
       "objclass": "PlantProperties",
       "objdata": {
-        "ShootInterval": 1.35,
-        "ShootIntervalAdditional": 0.15,
-        "PlantfoodPeaCount": 60,
-        "Cooldown": 5,
-        "SunCost": 100,
-        "Toughness": 300
+        "SunCost": 50,
+        "Damage": 40,
+        "Cooldown": 3,
+        "Toughness": 600
       }
     }
   ]
 }
 ```
 
-### Almanac Example (PlantAlmanac.json)
+**What this does:**
+- Sun cost: 100 → 50
+- Damage: 20 → 40 (double damage)
+- Cooldown: 5s → 3s (faster recharge)
+- Health: 300 → 600 (survives longer)
+
+## Example: Change Store Prices
+
+**File: `patches/jsons/features/StoreCommodityFeatures.json`**
 
 ```json
 {
-  "objects": [
+  "Plants": [
     {
-      "aliases": ["peashooter"],
-      "objclass": "PlantAlmanacProperties",
-      "objdata": {
-        "Elements": [
-          { "TYPE": "SUNCOST" },
-          { "TYPE": "DAMAGE", "VALUE": 20 }
-        ],
-        "Introduction": { "en": "Peashooters are...", "zh": "豌豆射手是..." }
-      }
+      "CommodityType": "plant",
+      "CommodityName": "snowpea",
+      "CurrencyType": "coin",
+      "CurrencyRequired": 1000
     }
   ]
 }
 ```
 
-### Merging Rules
+**What this does:**
+- Snow Pea now costs 1000 coins instead of gems
 
-- Same as Features: Match target entity by `aliases` (first item in array), then recursively merge `objdata`. If you only want to modify certain fields, provide only the properties that need modification.
+## Merging Rules
 
-## Level Files
+GE Patcher uses **smart merging** - you only need to specify what you want to change:
 
-Custom levels are placed in `patches/jsons/levels/[LevelName].json`.
+| Data Type | Merge Behavior |
+|-----------|----------------|
+| Primitives (string, number) | Replaced entirely |
+| Objects | Merged recursively |
+| Arrays | Merged by index (first element matches first element) |
+| Top-level arrays (`SEEDCHOOSERDEFAULTORDER`, etc.) | Replaced entirely |
 
-- The filename must match the in-game level ID (e.g., `egypt1.json`).
-- Use `gePatcher.showLevels()` in the console to view available level IDs (requires initializing GE Patcher first).
+> [!important]
+> **Limitations:**
+> - GE Patcher only **modifies existing entities** - you cannot add new plants/zombies
+> - Avoid changing key identifiers (`ID`, `_CARDSPRITENAME`, `CODENAME`)
 
-## Store Files
+## Troubleshooting
 
-`StoreCommodityFeatures.json` is used to replace/modify store item categories:
+### "Failed to load..." error
 
-```json
-{
-  "Plants": [],
-  "Upgrade": [],
-  "Gem": [],
-  "Coin": []
-}
+**Cause:** JSON syntax error
+
+**Fix:**
+1. Validate your JSON at [jsonlint.com](https://jsonlint.com/)
+2. Check for missing commas, brackets, or quotes
+3. Ensure proper escaping of special characters
+
+### "Level file not found" error
+
+**Cause:** Filename doesn't match level ID
+
+**Fix:**
+1. Run `gePatcher.showLevels()` to see valid level IDs
+2. Rename your file to match exactly (e.g., `egypt1.json`, not `Egypt1.json`)
+
+### Changes don't appear in-game
+
+**Cause:** Patches not reloaded
+
+**Fix:**
+1. Run `gePatcher.initPatchs()` after saving changes
+2. Check console for error messages
+3. Verify file is in correct directory (`patches/jsons/features/`)
+
+### Game crashes after applying patch
+
+**Cause:** Invalid data structure or values
+
+**Fix:**
+1. Remove your patch files
+2. Run `gePatcher.restoreAll()`
+3. Export original data: `gePatcher.exportJson('PlantProps', true)`
+4. Compare your JSON structure with the original
+5. Start with minimal changes and test incrementally
+
+### Properties not listed in documentation
+
+**Fix:** Export original data to discover all available properties:
+
+```javascript
+gePatcher.exportJson('PlantProps', true)
+gePatcher.exportJson('ZombieProps', true)
 ```
 
-Categories not needing modification can be omitted.
+## Next Steps
 
-## Debugging and Common Troubleshooting
-
-1. Check error logs in the console (F12).
-2. Common errors:
-   - ❌ `Failed to load...`: Usually a JSON syntax error.
-   - ❌ `Level file not found`: Filename or path mismatch.
-3. Verify JSON: Use [JSONLint](https://jsonlint.com/) or VSCode JSON validation plugin.
-4. Get reference: Use commands like `gePatcher.exportJson('PlantProps', true)` to export original game data and compare structural differences.
-
-Troubleshooting suggestions:
-
-- First run `gePatcher.help()` in the console to output the base patch directory (example: `C:\Users\admin\AppData\Local\com.pvzge.app\patches`) and the list of supported paths to ensure files are in the correct location.
-- Run `gePatcher.init()` only after game resources are fully loaded, or run `gePatcher.initBase()` first and wait for completion (the script checks resource count and warns if not loaded).
-- If changes do not take effect, confirm that you have re-executed `gePatcher.init()` or `gePatcher.initPatchs()` and check console output to locate errors.
+- See [Properties Reference](format.md) for complete property documentation
+- Check the [Almanac](../../almanac/) for valid property values per plant
+- Join the [Discord](https://discord.gg/m84nmRMFuf) for modding help
 


### PR DESCRIPTION
## Summary by Sourcery

改进并重构 PvZ2 Gardendless 的模组编写文档，以提供更清晰的、循序渐进的 GE Patcher 教程，以及更易用的属性参考。

Documentation:
- 将 GE Patcher 教程重写为引导式的分步工作流程，涵盖环境搭建、文件夹结构、补丁的加载/重新加载、示例以及故障排查。
- 扩展模组格式参考，加入速查表，更清晰地解释植物/僵尸/商店的 JSON 结构，并提供更安全的属性编辑指引。
- 修订主要的 MOD 指南入口页面，添加对模组功能与限制的概览、快速上手示例以及故障排查提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve and restructure the PvZ2 Gardendless modding docs to provide a clearer, step-by-step GE Patcher tutorial and a more usable property reference.

Documentation:
- Rewrite the GE Patcher tutorial into a guided step-by-step workflow covering setup, folder structure, loading/reloading patches, examples, and troubleshooting.
- Expand the modding format reference with quick-reference tables, clearer explanations of plant/zombie/store JSON structures, and safer editing guidance for properties.
- Revise the main MOD guide landing page with an overview of modding capabilities and limitations, a quick-start example, and troubleshooting tips.

</details>