### PR TITLE
fix: 修复 Star 历史图表链接，使其恢复正常显示

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Deploy the game locally by using [Docker image](https://hub.docker.com/r/gaozih/
 
 <div align="center">
     
-![Star History Chart](https://api.star-history.com/svg?repos=Gzh0821/pvzg_site&type=date&legend=top-left)
+![Star History Chart](https://star-history.dera.page/svg?repos=Gzh0821/pvzg_site&type=date&legend=top-left)
 
 </div>
 


### PR DESCRIPTION
Star 历史图表目前已经损坏，无法正常加载，这会影响使用者对项目热度的了解。本 PR 将图表切换到可用的服务地址以恢复其正常显示。

## Summary by Sourcery

文档：
- 调整 README 中的 Star 历史图表链接，以使用可正常工作的服务端点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Adjust the Star history chart link in the README to use a functioning service endpoint.

</details>